### PR TITLE
HOTFIX | Self Reported bug where the 404 middleware is declared before the csrf middleware resulting custom 404 page not rendering

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,16 +74,6 @@ app.set('view engine', 'ejs');
 app.use('/', require('./server/routes/main.js'));
 app.use('/', require('./server/routes/admin.js'));
 
-// 404 Not Found Middleware
-app.use((req, res, next) => {
-    const locals = {
-        title: '404 - Page Not Found',
-        description: '404 Not Found',
-        config: res.locals.siteConfig
-    }
-    res.status(404).render('404', {locals, csrfToken: req.csrfToken()});
-});
-
 // Middleware to protect routes, CSRF Error Handler
 app.use(function (err, req, res, next) {
     if (err.code !== 'EBADCSRFTOKEN'){
@@ -101,6 +91,17 @@ app.use(function (err, req, res, next) {
     });
     res.send('Form tampered with');
 });
+
+// 404 Not Found Middleware
+app.use((req, res, next) => {
+    const locals = {
+        title: '404 - Page Not Found',
+        description: '404 Not Found',
+        config: res.locals.siteConfig
+    }
+    res.status(404).render('404', {locals, csrfToken: req.csrfToken()});
+});
+
 
 // Start the server
 app.listen(PORT , () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the order of error handling to ensure 404 pages are shown after CSRF errors are processed. No visible changes to the 404 page itself.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->