### PR TITLE
Potential fix for code scanning alert no. 65: Missing rate limiting

### DIFF
--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -70,6 +70,7 @@ const fetchSiteConfig = async (req, res, next) => {
 }
 
 //Use Middleware.
+router.use(genericGetRequestRateLimiter);
 router.use(fetchSiteConfig);
 
 /**


### PR DESCRIPTION
Fix for [https://github.com/Debagnik/project-kurumi/security/code-scanning/65](https://github.com/Debagnik/project-kurumi/security/code-scanning/65)

The best way to fix this issue is to apply rate limiting middleware to requests handled by this router, specifically before the `fetchSiteConfig` middleware. Express supports rate limiting via popular libraries like `express-rate-limit`. The code already imports several rate limiters from `../../utils/rateLimiter` (line 14), likely custom wrappers around such libraries. The most appropriate rate limiter, given its name, is probably `genericGetRequestRateLimiter`, since fetching the site config usually happens on non-mutating GET requests.

To best address this, insert the relevant rate limiter (`genericGetRequestRateLimiter`) as middleware before `fetchSiteConfig` so all incoming requests are rate-limited before any database access. This is implemented by inserting `router.use(genericGetRequestRateLimiter)` above (or as the first middleware before) `router.use(fetchSiteConfig)`.

No new function definitions are needed if the rate limiter is already imported.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced global request rate limiting across all routes; excessive requests may be temporarily throttled.
  * Rate limits are applied consistently after initial configuration is loaded.
  * No changes to individual route behavior beyond the new rate limiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->